### PR TITLE
net/context: new new canonical url

### DIFF
--- a/minfraud.go
+++ b/minfraud.go
@@ -1,9 +1,10 @@
 package minfraud
 
 import (
-	"code.google.com/p/go.net/context"
-	"github.com/savaki/httpctx"
 	"log"
+
+	"github.com/savaki/httpctx"
+	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
The net/context project is no longer available at the code.google.com URL.
